### PR TITLE
Document updatePlaces utility script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Les objets listés dans `experiences` peuvent désormais stocker des métadonné
 - **Identifiant lieu (`placeId`)** : privilégiez l'identifiant Google Places lorsque disponible pour éviter les doublons lors des synchronisations.
 - **Source** : conservez la provenance des données (`name`, `url`, `retrievedAt`) pour faciliter les mises à jour ultérieures.
 
+## Scripts utilitaires
+
+Un script Node.js permet d'enrichir automatiquement les expériences avec les métadonnées Google Places :
+
+```bash
+GOOGLE_API_KEY="votre-cle" node scripts/updatePlaces.mjs <ville> [pays]
+```
+
+Consultez la documentation dédiée dans [scripts/updatePlaces.md](scripts/updatePlaces.md) pour comprendre les options disponibles et les bonnes pratiques d'exécution.
+
 ## Accessibilité & bonnes pratiques
 
 - Contrastes vérifiés pour répondre aux recommandations WCAG AA.


### PR DESCRIPTION
## Summary
- restore the README guidance for running the updatePlaces utility script with the correct command and documentation link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced5512e5083248d4e93986e7a0f4c